### PR TITLE
Stats fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "osm-gamification-api",
-  "version": "0.0.1",
+  "name": "osm-stats-api",
+  "version": "0.3.3",
   "description": "An API for Missing Maps statistics",
   "main": "index.js",
   "scripts": {

--- a/routes/company-page.js
+++ b/routes/company-page.js
@@ -25,7 +25,7 @@ module.exports = [
                         SUM(waterway_km_add) AS waterway_km_add, \
                         hashtag \
                       FROM changesets JOIN \
-                        (SELECT changeset_id, hashtag FROM changesets_hashtags \
+                        (SELECT DISTINCT changeset_id, hashtag FROM changesets_hashtags \
                         JOIN hashtags ON changesets_hashtags.hashtag_id=hashtags.id \
                         WHERE hashtag IN (" + hashtags + ")) AS filtered \
                       ON changesets.id=filtered.changeset_id \

--- a/routes/hashtag.js
+++ b/routes/hashtag.js
@@ -97,9 +97,12 @@ module.exports = [
       .where('hashtags.hashtag', req.params.id);
 
       var knex = bookshelf.knex;
-      knex.select('user_id', 'name', knex.raw('COUNT(*) as edits'),
+      knex.select('user_id', 'name', knex.raw('COUNT(*) as changesets'),
                   knex.raw('SUM(road_km_mod + road_km_add) as roads'),
                   knex.raw('SUM(building_count_add + building_count_mod) as buildings'),
+                  knex.raw('SUM(building_count_add + building_count_mod + \
+                            road_count_add + road_count_mod + \
+                            waterway_count_add + poi_count_add) as edits'),
                   knex.raw('MAX(changesets.created_at) as created_at'))
           .from('changesets')
           .join('users', 'changesets.user_id', 'users.id')
@@ -111,6 +114,7 @@ module.exports = [
                 "name": row.name,
                 "user_id": row.user_id,
                 "edits": Number(row.edits),
+                "changesets": Number(row.changesets),
                 "roads": Number(Number(row.roads).toFixed(3)),
                 "buildings": parseInt(row.buildings),
                 "created_at": row.created_at


### PR DESCRIPTION
@matthewhanson
Please update to 0.3.3 when you have a chance. Let us know when you're going to do it, because we'll want to update the leaderboard site fairly soon after you do; the hashtag/user's edit attribute will now refer to total edits rather than total changesets and we should change the label accordingly. This also fixes counting of duplicate changesets in the company-page endpoint.